### PR TITLE
Use centralized API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://localhost:53759

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:53759';
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+});

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'https://localhost:53759/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/api/:path*`,
       },
     ];
   },

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import axios from 'axios';
+import { api } from '../lib/api';
 
 interface User {
   id: string;
@@ -33,7 +33,6 @@ interface RegisterData {
   companyPhone: string;
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:53759';
 
 export const useAuthStore = create<AuthState>()(
   persist(
@@ -44,7 +43,7 @@ export const useAuthStore = create<AuthState>()(
 
       login: async (email: string, password: string) => {
         try {
-          const response = await axios.post(`${API_BASE_URL}/api/auth/login`, {
+          const response = await api.post('/api/auth/login', {
             email,
             password,
           });
@@ -54,7 +53,7 @@ export const useAuthStore = create<AuthState>()(
           set({ user, token, isLoading: false });
           
           // Set axios default header
-          axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
         } catch (error: any) {
           throw new Error(error.response?.data?.message || 'Giriş başarısız');
         }
@@ -62,14 +61,14 @@ export const useAuthStore = create<AuthState>()(
 
       register: async (data: RegisterData) => {
         try {
-          const response = await axios.post(`${API_BASE_URL}/api/auth/register`, data);
+          const response = await api.post('/api/auth/register', data);
           
           const { token, user } = response.data;
           
           set({ user, token, isLoading: false });
           
           // Set axios default header
-          axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
         } catch (error: any) {
           throw new Error(error.response?.data?.message || 'Kayıt başarısız');
         }
@@ -77,7 +76,7 @@ export const useAuthStore = create<AuthState>()(
 
       logout: () => {
         set({ user: null, token: null });
-        delete axios.defaults.headers.common['Authorization'];
+        delete api.defaults.headers.common['Authorization'];
       },
 
       setUser: (user: User) => {
@@ -87,7 +86,7 @@ export const useAuthStore = create<AuthState>()(
       initializeAuth: () => {
         const { token } = get();
         if (token) {
-          axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
         }
         set({ isLoading: false });
       },

--- a/store/companyStore.ts
+++ b/store/companyStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import axios from 'axios';
+import { api } from '../lib/api';
 
 interface Company {
   id: number;
@@ -36,7 +36,6 @@ interface CompanyState {
   uploadLogo: (file: File) => Promise<void>;
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:53759';
 
 export const useCompanyStore = create<CompanyState>((set, get) => ({
   company: null,
@@ -46,7 +45,7 @@ export const useCompanyStore = create<CompanyState>((set, get) => ({
   fetchCompany: async () => {
     set({ loading: true, error: null });
     try {
-      const response = await axios.get(`${API_BASE_URL}/api/company/me`);
+      const response = await api.get('/api/company/me');
       set({ company: response.data, loading: false });
     } catch (error: any) {
       set({ 
@@ -58,7 +57,7 @@ export const useCompanyStore = create<CompanyState>((set, get) => ({
 
   updateCompany: async (data: UpdateCompanyData) => {
     try {
-      const response = await axios.put(`${API_BASE_URL}/api/company`, data);
+      const response = await api.put('/api/company', data);
       set({ company: response.data });
     } catch (error: any) {
       throw new Error(error.response?.data?.message || 'Şirket bilgileri güncellenemedi');
@@ -70,7 +69,7 @@ export const useCompanyStore = create<CompanyState>((set, get) => ({
       const formData = new FormData();
       formData.append('logo', file);
       
-      await axios.post(`${API_BASE_URL}/api/company/logo`, formData, {
+      await api.post('/api/company/logo', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },

--- a/store/offerStore.ts
+++ b/store/offerStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import axios from 'axios';
+import { api } from '../lib/api';
 
 interface OfferItem {
   id: number;
@@ -57,7 +57,6 @@ interface OfferState {
   setCurrentOffer: (offer: Offer | null) => void;
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:53759';
 
 export const useOfferStore = create<OfferState>((set, get) => ({
   offers: [],
@@ -68,7 +67,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
   fetchOffers: async () => {
     set({ loading: true, error: null });
     try {
-      const response = await axios.get(`${API_BASE_URL}/api/offers`);
+      const response = await api.get('/api/offers');
       set({ offers: response.data, loading: false });
     } catch (error: any) {
       set({ 
@@ -81,7 +80,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
   fetchOffer: async (id: number) => {
     set({ loading: true, error: null });
     try {
-      const response = await axios.get(`${API_BASE_URL}/api/offers/${id}`);
+      const response = await api.get(`/api/offers/${id}`);
       set({ currentOffer: response.data, loading: false });
     } catch (error: any) {
       set({ 
@@ -93,7 +92,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
 
   createOffer: async (data: CreateOfferData) => {
     try {
-      const response = await axios.post(`${API_BASE_URL}/api/offers`, data);
+      const response = await api.post('/api/offers', data);
       const newOffer = response.data;
       
       set((state) => ({
@@ -108,7 +107,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
 
   updateOffer: async (id: number, data: CreateOfferData) => {
     try {
-      const response = await axios.put(`${API_BASE_URL}/api/offers/${id}`, data);
+      const response = await api.put(`/api/offers/${id}`, data);
       const updatedOffer = response.data;
       
       set((state) => ({
@@ -126,7 +125,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
 
   deleteOffer: async (id: number) => {
     try {
-      await axios.delete(`${API_BASE_URL}/api/offers/${id}`);
+      await api.delete(`/api/offers/${id}`);
       
       set((state) => ({
         offers: state.offers.filter((offer) => offer.id !== id),
@@ -139,7 +138,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
 
   sendOffer: async (id: number) => {
     try {
-      await axios.post(`${API_BASE_URL}/api/offers/${id}/send`);
+      await api.post(`/api/offers/${id}/send`);
       
       set((state) => ({
         offers: state.offers.map((offer) => 


### PR DESCRIPTION
## Summary
- add `lib/api.ts` with shared axios instance
- read API base URL from `.env.example`
- replace hardcoded API URLs in stores
- wire `NEXT_PUBLIC_API_URL` into `next.config.js`

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6870fcb6b4f8832db532f4bf9ab85e47