### PR TITLE
Connect users page with backend services

### DIFF
--- a/app/dashboard/users/page.tsx
+++ b/app/dashboard/users/page.tsx
@@ -1,13 +1,15 @@
-import UsersClient from './UsersClient';
-import { api } from '@/lib/api';
+'use client';
 
-export default async function UsersPage() {
-  try {
-    const response = await api.get('/api/users');
-    const users = response.data as any[];
-    return <UsersClient initialUsers={users} />;
-  } catch (error) {
-    console.error('Failed to fetch users', error);
-    return <UsersClient initialUsers={[]} />;
-  }
+import { useEffect } from 'react';
+import UsersClient from './UsersClient';
+import { useUserStore } from '@/store/userStore';
+
+export default function UsersPage() {
+  const { fetchUsers } = useUserStore();
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return <UsersClient />;
 }

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -1,0 +1,104 @@
+import { create } from 'zustand';
+import { api } from '../lib/api';
+
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  companyId?: number;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface CreateUserData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+}
+
+export interface UpdateUserData {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+interface UserState {
+  users: User[];
+  loading: boolean;
+  error: string | null;
+  setUsers: (users: User[]) => void;
+  fetchUsers: () => Promise<void>;
+  createUser: (data: CreateUserData) => Promise<User>;
+  updateUser: (id: string, data: UpdateUserData) => Promise<User>;
+  deleteUser: (id: string) => Promise<void>;
+  toggleUserStatus: (id: string) => Promise<void>;
+}
+
+export const useUserStore = create<UserState>((set, get) => ({
+  users: [],
+  loading: false,
+  error: null,
+
+  setUsers: (users: User[]) => set({ users }),
+
+  fetchUsers: async () => {
+    set({ loading: true, error: null });
+    try {
+      const response = await api.get('/api/users');
+      set({ users: response.data, loading: false });
+    } catch (error: any) {
+      set({
+        error: error.response?.data?.message || 'Kullanıcılar yüklenemedi',
+        loading: false,
+      });
+    }
+  },
+
+  createUser: async (data: CreateUserData) => {
+    try {
+      const response = await api.post('/api/users', data);
+      const newUser: User = response.data;
+      set((state) => ({ users: [...state.users, newUser] }));
+      return newUser;
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'Kullanıcı oluşturulamadı');
+    }
+  },
+
+  updateUser: async (id: string, data: UpdateUserData) => {
+    try {
+      const response = await api.put(`/api/users/${id}`, data);
+      const updatedUser: User = response.data;
+      set((state) => ({
+        users: state.users.map((u) => (u.id === id ? updatedUser : u)),
+      }));
+      return updatedUser;
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'Kullanıcı güncellenemedi');
+    }
+  },
+
+  deleteUser: async (id: string) => {
+    try {
+      await api.delete(`/api/users/${id}`);
+      set((state) => ({ users: state.users.filter((u) => u.id !== id) }));
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'Kullanıcı silinemedi');
+    }
+  },
+
+  toggleUserStatus: async (id: string) => {
+    try {
+      await api.post(`/api/users/${id}/toggle-status`);
+      set((state) => ({
+        users: state.users.map((u) =>
+          u.id === id ? { ...u, isActive: !u.isActive } : u
+        ),
+      }));
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'Kullanıcı durumu güncellenemedi');
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- add a zustand userStore for CRUD operations
- refactor UsersClient to use userStore
- convert Users page to client component that fetches users

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687214c76290832dafb3fed5062c74a7