### PR TITLE
Improve product autocomplete in new offer form

### DIFF
--- a/app/dashboard/offers/new/page.tsx
+++ b/app/dashboard/offers/new/page.tsx
@@ -8,6 +8,7 @@ import { useProductStore } from '@/store/productStore';
 import { Plus, Trash2, ArrowLeft } from 'lucide-react';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
+import AutocompleteInput from '@/components/AutocompleteInput';
 
 interface OfferItem {
   productId?: number;
@@ -361,22 +362,16 @@ export default function NewOfferPage() {
                       <label className="block text-sm font-medium text-gray-700 mb-1">
                         Ürün
                       </label>
-                      <input
-                        list={`product-options-${index}`}
-                        type="text"
-                        className="input"
+                      <AutocompleteInput
                         value={item.description}
-                        onChange={(e) => {
-                          handleItemChange(index, 'description', e.target.value);
-                          handleProductSelect(index, e.target.value);
+                        onChange={(val) => {
+                          handleItemChange(index, 'description', val);
+                          handleProductSelect(index, val);
                         }}
+                        onOptionSelect={(val) => handleProductSelect(index, val)}
+                        options={products.map((p) => p.name)}
                         placeholder="Ürün ara veya yeni ekle"
                       />
-                      <datalist id={`product-options-${index}`}>
-                        {products.map((p) => (
-                          <option key={p.id} value={p.name} />
-                        ))}
-                      </datalist>
                     </div>
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect, useRef } from 'react';
+
+interface AutocompleteInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder?: string;
+  onOptionSelect?: (value: string) => void;
+}
+
+export default function AutocompleteInput({
+  value,
+  onChange,
+  options,
+  placeholder,
+  onOptionSelect,
+}: AutocompleteInputProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = options.filter((option) =>
+    option.toLowerCase().includes(value.toLowerCase())
+  );
+
+  useEffect(() => {
+    const listener = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', listener);
+    return () => document.removeEventListener('mousedown', listener);
+  }, []);
+
+  const handleSelect = (val: string) => {
+    onChange(val);
+    onOptionSelect?.(val);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        type="text"
+        className="input"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+      />
+      {open && filtered.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">
+          {filtered.map((option) => (
+            <li
+              key={option}
+              onClick={() => handleSelect(option)}
+              className="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {option}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `AutocompleteInput` component for dropdown suggestions
- use `AutocompleteInput` in new offer page for product entry

## Testing
- `npm run lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872489c26bc832da2248a13152209a5