### PR TITLE
UI updates for new subscription limits

### DIFF
--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useCompanyStore } from '@/store/companyStore';
+import { useUserStore } from '@/store/userStore';
 import PaymentModal from '@/components/PaymentModal';
 import toast from 'react-hot-toast';
 import { 
@@ -21,14 +22,14 @@ const plans = [
     currency: 'TRY',
     interval: 'aylık',
     features: [
-      '5 teklif/ay',
-      // '1 kullanıcı',
+      '3 teklif/ay',
+      '2 kullanıcı',
       // 'Temel şablonlar',
       'E-posta desteği',
     ],
     limits: {
-      offers: 5,
-      users: 1,
+      offers: 3,
+      users: 2,
       storage: '500MB',
     },
   },
@@ -57,13 +58,15 @@ const plans = [
 
 export default function BillingPage() {
   const { company, fetchCompany, upgradePlan } = useCompanyStore();
+  const { users, fetchUsers } = useUserStore();
   const [selectedPlan, setSelectedPlan] = useState<{name: string; price: number} | null>(null);
   const [processing, setProcessing] = useState(false);
   const [showPayment, setShowPayment] = useState(false);
 
   useEffect(() => {
     fetchCompany();
-  }, [fetchCompany]);
+    fetchUsers();
+  }, [fetchCompany, fetchUsers]);
 
   const handlePlanSelect = (planName: string, price: number) => {
     setSelectedPlan({ name: planName, price });
@@ -144,11 +147,11 @@ export default function BillingPage() {
               <div className="mt-2 bg-gray-200 rounded-full h-2">
                 <div
                   className="bg-blue-600 h-2 rounded-full"
-                  style={{ width: `${company ? Math.min((company.offersUsed / 5) * 100, 100) : 0}%` }}
+                  style={{ width: `${company ? Math.min((company.offersUsed / 3) * 100, 100) : 0}%` }}
                 ></div>
               </div>
               <p className="text-xs text-gray-500 mt-1">
-                {company?.subscriptionPlan === 'Free' ? '5 limitinden' : 'Sınırsız'}
+                {company?.subscriptionPlan === 'Free' ? '3 limitinden' : 'Sınırsız'}
               </p>
             </div>
             
@@ -156,14 +159,19 @@ export default function BillingPage() {
               <div className="h-12 w-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
                 <Users className="h-6 w-6 text-green-600" />
               </div>
-              <p className="text-2xl font-bold text-gray-900">3</p>
+              <p className="text-2xl font-bold text-gray-900">{users.length}</p>
               <p className="text-sm text-gray-500">Aktif Kullanıcı</p>
               <div className="mt-2 bg-gray-200 rounded-full h-2">
-                <div className="bg-green-600 h-2 rounded-full" style={{ width: '60%' }}></div>
+                <div
+                  className="bg-green-600 h-2 rounded-full"
+                  style={{
+                    width: `${company ? Math.min((users.length / (company.subscriptionPlan === 'Free' ? 2 : company.subscriptionPlan === 'Pro' ? 5 : users.length || 1)) * 100, 100) : 0}%`
+                  }}
+                ></div>
               </div>
               <p className="text-xs text-gray-500 mt-1">
                 {
-                company?.subscriptionPlan === 'Free' ? '1 limitinden' :
+                company?.subscriptionPlan === 'Free' ? '2 limitinden' :
                  company?.subscriptionPlan === 'Pro' ? '5 limitinden' :
                  'Sınırsız'                
                 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useCompanyStore } from '@/store/companyStore';
 import Sidebar from '@/components/Sidebar';
 import Header from '@/components/Header';
+import SubscriptionExpired from '@/components/SubscriptionExpired';
 
 export default function DashboardLayout({
   children,
@@ -13,7 +14,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const { user, isLoading } = useAuthStore();
-  const { fetchCompany } = useCompanyStore();
+  const { company, fetchCompany } = useCompanyStore();
   const router = useRouter();
 
   useEffect(() => {
@@ -37,6 +38,10 @@ export default function DashboardLayout({
 
   if (!user) {
     return null;
+  }
+
+  if (company && !company.isActive) {
+    return <SubscriptionExpired subscriptionEndDate={company.subscriptionEndDate} />;
   }
 
   return (

--- a/app/dashboard/users/UsersClient.tsx
+++ b/app/dashboard/users/UsersClient.tsx
@@ -3,6 +3,7 @@
 import { useState,useEffect } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useUserStore } from '@/store/userStore';
+import { useCompanyStore } from '@/store/companyStore';
 import {
   Plus,
   Trash2,
@@ -21,6 +22,7 @@ export default function UsersClient() {
   const { user: currentUser } = useAuthStore();
   const { users, fetchUsers, createUser, deleteUser, toggleUserStatus } =
     useUserStore();
+  const { company } = useCompanyStore();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -79,7 +81,12 @@ export default function UsersClient() {
           <h1 className="text-2xl font-bold text-gray-900">Kullanıcı Yönetimi</h1>
           <p className="text-gray-600">Şirket kullanıcılarını yönetin ve düzenleyin.</p>
         </div>
-        <button onClick={() => setShowCreateModal(true)} className="btn btn-primary btn-md">
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="btn btn-primary btn-md"
+          disabled={company?.subscriptionPlan === 'Free' && users.length >= 2}
+          title={company?.subscriptionPlan === 'Free' && users.length >= 2 ? 'Ücretsiz planda en fazla 2 kullanıcı ekleyebilirsiniz.' : ''}
+        >
           <Plus className="h-4 w-4 mr-2" />
           Yeni Kullanıcı
         </button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -39,7 +39,7 @@ export default function Header() {
               className="hidden sm:block text-sm text-gray-600 dark:text-gray-300 mr-2 hover:underline cursor-pointer"
             >
               {company.subscriptionPlan === 'Free'
-                ? `Ücretsiz Plan - ${company.offersUsed}/5`
+                ? `Ücretsiz Plan - ${company.offersUsed}/3`
                 : `${company.subscriptionPlan} Planı`}
             </a>
           )}

--- a/components/SubscriptionExpired.tsx
+++ b/components/SubscriptionExpired.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface SubscriptionExpiredProps {
+  subscriptionEndDate?: string;
+}
+
+export default function SubscriptionExpired({ subscriptionEndDate }: SubscriptionExpiredProps) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-6">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md text-center space-y-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Aboneliğiniz sona erdi</h2>
+        {subscriptionEndDate && (
+          <p className="text-gray-700 dark:text-gray-300">
+            {new Date(subscriptionEndDate).toLocaleDateString('tr-TR')} tarihinde aboneliğiniz sona erdi.
+          </p>
+        )}
+        <a href="/dashboard/billing" className="btn btn-primary btn-md">
+          Aboneliği Yenile
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/store/offerStore.ts
+++ b/store/offerStore.ts
@@ -141,7 +141,7 @@ export const useOfferStore = create<OfferState>((set, get) => ({
   sendOffer: async (id: number) => {
     try {
       const { company, fetchCompany } = useCompanyStore.getState();
-      if (company && company.subscriptionPlan === 'Free' && company.offersUsed >= 5) {
+      if (company && company.subscriptionPlan === 'Free' && company.offersUsed >= 3) {
         throw new Error('Ücretsiz plan limiti doldu. Lütfen planınızı yükseltin.');
       }
 

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api } from '../lib/api';
+import { useCompanyStore } from './companyStore';
 
 export interface User {
   id: string;
@@ -58,12 +59,18 @@ export const useUserStore = create<UserState>((set, get) => ({
 
   createUser: async (data: CreateUserData) => {
     try {
+      const { company } = useCompanyStore.getState();
+      const { users } = get();
+      if (company && company.subscriptionPlan === 'Free' && users.length >= 2) {
+        throw new Error('Ücretsiz planda en fazla 2 kullanıcı ekleyebilirsiniz.');
+      }
+
       const response = await api.post('/api/users', data);
       const newUser: User = response.data;
       set((state) => ({ users: [...state.users, newUser] }));
       return newUser;
     } catch (error: any) {
-      throw new Error(error.response?.data?.message || 'Kullanıcı oluşturulamadı');
+      throw new Error(error.response?.data?.message || error.message || 'Kullanıcı oluşturulamadı');
     }
   },
 


### PR DESCRIPTION
## Summary
- block dashboard usage when subscription expired
- show dynamic user count and new free plan limits
- enforce user limit when creating new users
- update offer limit references for free plan

## Testing
- `npm install` *(fails: blocked)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874da730d48832dadf53d4bfa79f59a