### PR TITLE
Make billing page dynamic using new payment APIs

### DIFF
--- a/store/companyStore.ts
+++ b/store/companyStore.ts
@@ -35,7 +35,7 @@ interface CompanyState {
   fetchCompany: () => Promise<void>;
   updateCompany: (data: UpdateCompanyData) => Promise<void>;
   uploadLogo: (file: File) => Promise<void>;
-  upgradePlan: (plan: string) => Promise<void>;
+  upgradePlan: (plan: string, amount: number) => Promise<void>;
 }
 
 
@@ -84,9 +84,13 @@ export const useCompanyStore = create<CompanyState>((set, get) => ({
     }
   },
 
-  upgradePlan: async (plan: string) => {
+  upgradePlan: async (plan: string, amount: number) => {
     try {
-      const response = await api.post('/api/company/upgrade', { plan });
+      const response = await api.post('/api/company/upgrade', {
+        plan,
+        amount,
+        transactionId: Math.random().toString(36).substring(2, 10),
+      });
       set({ company: response.data });
     } catch (error: any) {
       throw new Error(error.response?.data?.message || 'Plan yükseltilemedi');

--- a/store/paymentStore.ts
+++ b/store/paymentStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { api } from '../lib/api';
+
+export interface Payment {
+  id: number;
+  amount: number;
+  paidAt: string;
+  transactionId?: string;
+}
+
+interface PaymentState {
+  payments: Payment[];
+  loading: boolean;
+  error: string | null;
+  fetchPayments: () => Promise<void>;
+}
+
+export const usePaymentStore = create<PaymentState>((set) => ({
+  payments: [],
+  loading: false,
+  error: null,
+  fetchPayments: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await api.get('/api/company/payments');
+      set({ payments: res.data, loading: false });
+    } catch (error: any) {
+      set({
+        error: error.response?.data?.message || 'Ödemeler yüklenemedi',
+        loading: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- add zustand store for payments
- update company store to include amount when upgrading plan
- fetch offers and payments in billing page for dynamic stats
- show this month's offer total and payment history

## Testing
- `npx next lint` *(fails: Next.js not installed? actually interactive message)*

------
https://chatgpt.com/codex/tasks/task_e_6874fe0e7090832dbea073e75fe7b386