### PR TITLE
Add admin dashboard page

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useAdminStore } from '@/store/adminStore';
+import { useAuthStore } from '@/store/authStore';
+import toast from 'react-hot-toast';
+import {
+  Building2,
+  Shield,
+  TrendingUp,
+} from 'lucide-react';
+
+export default function AdminDashboardPage() {
+  const { user } = useAuthStore();
+  const { dashboard, fetchDashboard, upgradeCompany, loading } = useAdminStore();
+
+  useEffect(() => {
+    if (user) {
+      fetchDashboard();
+    }
+  }, [user, fetchDashboard]);
+
+  const handleUpgrade = async (id: number) => {
+    try {
+      await upgradeCompany(id);
+      toast.success('Şirket Pro pakete geçirildi');
+    } catch (error: any) {
+      toast.error(error.message);
+    }
+  };
+
+  if (loading && !dashboard) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Yönetici Paneli</h1>
+        <p className="text-gray-600">Uygulama genel özetini görüntüleyin.</p>
+      </div>
+
+      {dashboard && (
+        <>
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="card">
+              <div className="card-body p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Toplam Şirket</p>
+                    <p className="text-2xl font-bold text-gray-900">{dashboard.totalCompanies}</p>
+                  </div>
+                  <Building2 className="h-6 w-6 text-primary-600" />
+                </div>
+              </div>
+            </div>
+            <div className="card">
+              <div className="card-body p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Pro Şirket</p>
+                    <p className="text-2xl font-bold text-gray-900">{dashboard.proCompanies}</p>
+                  </div>
+                  <Shield className="h-6 w-6 text-secondary-600" />
+                </div>
+              </div>
+            </div>
+            <div className="card">
+              <div className="card-body p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Bugünkü Gelir</p>
+                    <p className="text-2xl font-bold text-gray-900">{dashboard.revenueToday.toLocaleString('tr-TR', { style: 'currency', currency: 'TRY' })}</p>
+                  </div>
+                  <TrendingUp className="h-6 w-6 text-accent-600" />
+                </div>
+              </div>
+            </div>
+            <div className="card">
+              <div className="card-body p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">Toplam Gelir</p>
+                    <p className="text-2xl font-bold text-gray-900">{dashboard.revenueTotal.toLocaleString('tr-TR', { style: 'currency', currency: 'TRY' })}</p>
+                  </div>
+                  <TrendingUp className="h-6 w-6 text-success-600" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-header">
+              <h2 className="text-lg font-semibold">Şirketler</h2>
+            </div>
+            <div className="card-body">
+              <div className="overflow-x-auto">
+                <table className="table">
+                  <thead className="table-header">
+                    <tr>
+                      <th className="table-head">Şirket</th>
+                      <th className="table-head">Teklif</th>
+                      <th className="table-head">Kullanıcı</th>
+                      <th className="table-head">Plan</th>
+                      <th className="table-head">İşlem</th>
+                    </tr>
+                  </thead>
+                  <tbody className="table-body">
+                    {dashboard.companies.map((c) => (
+                      <tr key={c.id} className="table-row">
+                        <td className="table-cell font-medium">{c.name}</td>
+                        <td className="table-cell">{c.offerCount}</td>
+                        <td className="table-cell">{c.userCount}</td>
+                        <td className="table-cell capitalize">{c.subscriptionPlan}</td>
+                        <td className="table-cell">
+                          {c.subscriptionPlan === 'Free' && (
+                            <button onClick={() => handleUpgrade(c.id)} className="btn btn-primary btn-xs">Proya Geçir</button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
 import {
   LayoutDashboard,
   FileText,
@@ -12,6 +13,7 @@ import {
   CreditCard,
   Settings,
   Package,
+  Shield,
   Menu,
   X
 } from 'lucide-react';
@@ -30,6 +32,12 @@ const navigation = [
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+  const { user } = useAuthStore();
+
+  const links = [...navigation];
+  if (user?.role === 'SuperAdmin') {
+    links.push({ name: 'Admin', href: '/dashboard/admin', icon: Shield });
+  }
 
   return (
     <>
@@ -54,7 +62,7 @@ export default function Sidebar() {
 
           {/* Navigation */}
           <nav className="flex-1 px-4 py-6 space-y-2">
-            {navigation.map((item) => {
+            {links.map((item) => {
               const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
               return (
                 <Link

--- a/store/adminStore.ts
+++ b/store/adminStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { api } from '../lib/api';
+
+export interface CompanySummary {
+  id: number;
+  name: string;
+  offerCount: number;
+  userCount: number;
+  subscriptionPlan: string;
+}
+
+export interface AdminDashboard {
+  companies: CompanySummary[];
+  totalCompanies: number;
+  proCompanies: number;
+  freeCompanies: number;
+  revenueToday: number;
+  revenueThisWeek: number;
+  revenueThisMonth: number;
+  revenueTotal: number;
+}
+
+interface AdminState {
+  dashboard: AdminDashboard | null;
+  loading: boolean;
+  error: string | null;
+  fetchDashboard: () => Promise<void>;
+  upgradeCompany: (id: number) => Promise<void>;
+}
+
+export const useAdminStore = create<AdminState>((set) => ({
+  dashboard: null,
+  loading: false,
+  error: null,
+
+  fetchDashboard: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await api.get('/api/admin/dashboard');
+      set({ dashboard: res.data, loading: false });
+    } catch (error: any) {
+      set({
+        error: error.response?.data?.message || 'Yönetici verileri yüklenemedi',
+        loading: false,
+      });
+    }
+  },
+
+  upgradeCompany: async (id: number) => {
+    try {
+      await api.post(`/api/admin/companies/${id}/upgrade`, {
+        plan: 'Pro',
+        amount: 0,
+        transactionId: 'admin',
+      });
+      // Refresh dashboard after upgrade
+      await (useAdminStore.getState().fetchDashboard());
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'Şirket yükseltilemedi');
+    }
+  },
+}));

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -7,6 +7,7 @@ interface User {
   firstName: string;
   lastName: string;
   email: string;
+  role?: string;
   companyId?: number;
   isActive: boolean;
   createdAt: string;


### PR DESCRIPTION
## Summary
- allow `User` object to include optional `role`
- provide admin dashboard store to fetch stats and upgrade companies
- add admin page under dashboard with company summaries and revenue stats
- show admin panel link for super admins in sidebar

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875012085b0832db0b70784f6a19dc5